### PR TITLE
Fix up stuff after rebasing openshift-ansible

### DIFF
--- a/hot/master_node.yaml
+++ b/hot/master_node.yaml
@@ -119,9 +119,9 @@ resources:
             # Prepare OpenShift ansible deployment
             yum install -y epel-release
             yum install -y ansible git
-            git clone https://github.com/celebdor/openshift-ansible /home/centos/openshift-ansible
+            git clone https://github.com/dulek/openshift-ansible /home/centos/openshift-ansible
             pushd /home/centos/openshift-ansible
-            git checkout kuryr_rebase
+            git checkout containerized_kuryr_support
             popd
             chown centos:centos -R /home/centos/openshift-ansible
 

--- a/hot/worker_node.yaml
+++ b/hot/worker_node.yaml
@@ -91,6 +91,8 @@ resources:
             fi
 
             hostnamectl set-hostname "__name__.__dns_domain__"
+            yum install -y NetworkManager
+            systemctl start NetworkManager
 
 outputs:
   trunk_port_id:

--- a/kuryr_heat_pike
+++ b/kuryr_heat_pike
@@ -136,8 +136,9 @@ openshift_use_kuryr=True
 openshift_use_openshift_sdn=False
 os_sdn_network_plugin_name=cni
 kuryr_cni_link_interface=eth0
-openshift_use_dnsmasq=False
+openshift_use_dnsmasq=True
 openshift_dns_ip=${external_dns}
+openshift_disable_check=disk_availability,docker_storage,memory_availability
 
 # Set userspace so that there's no iptables remains
 openshift_node_proxy_mode=userspace
@@ -161,8 +162,8 @@ openshift_hosted_manage_router=false
 
 # Openstack
 kuryr_openstack_auth_url=${OS_AUTH_URL}
-kuryr_openstack_user_domain_name=${OS_USER_DOMAIN_NAME}
-kuryr_openstack_user_project_name=${OS_PROJECT_DOMAIN_NAME}
+kuryr_openstack_user_domain_name=${OS_USER_DOMAIN_ID}
+kuryr_openstack_user_project_name=${OS_PROJECT_NAME}
 kuryr_openstack_project_id=${project_id}
 kuryr_openstack_username=${OS_USERNAME}
 kuryr_openstack_password=${OS_PASSWORD}


### PR DESCRIPTION
1. Switch to my repo with Kuryr support rebased to latest
   openshift-ansible (once PR is merged into official openshift-ansible
   we can get rid of that).
2. Install and start NetworkManager on worker nodes as required by
   latest openshift-ansible.
3. Enable dnsmasq in inventory as requred by latest openshift-ansible.
4. Disable RAM and storage checks (useful when debugging on smaller
   VMs).
5. Fix up environment variables names in variables generated for
   kuryr.conf.